### PR TITLE
Add CODEOWNERS (2026-06 governance review)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS
+# Added 2026-06 as part of the Sonetel org-wide repo-governance review (tech-debt issue #13).
+# Assigns the reviewed code owner(s) for this repository.
+#
+# NOTE: This file only auto-requests the listed owner(s) as reviewers on future PRs.
+# It does NOT gate or block merges. Required-review enforcement is a separate step
+# (tracked in issue #8) and is intentionally NOT enabled by this change.
+* @aashish-joshi


### PR DESCRIPTION
## Add CODEOWNERS — 2026-06 org governance review

Adds `.github/CODEOWNERS` assigning the reviewed code owner(s), per tech-debt issue #13 (2026-06 org-wide repo-governance review).

**This change is behavior-neutral.** A CODEOWNERS file on its own only auto-requests the listed owner(s) as reviewers on future PRs — it does not gate or block merges. Required-review enforcement is a separate, later step (tracked in #8) and is NOT enabled here.

Owner(s): @aashish-joshi

Refs #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)