### PR TITLE
docs: add .github/REPO-INFO.md (classification knowledge article) (#38)

### DIFF
--- a/.github/REPO-INFO.md
+++ b/.github/REPO-INFO.md
@@ -1,0 +1,21 @@
+---
+# Canonical repo classification — see docs/REPO-CLASSIFICATION.md.
+# This front-matter is the source of truth; GitHub topics mirror from it.
+content: code
+domain: dev-tooling
+exposure: developer
+lifecycle: inactive
+---
+
+# sonetel-python
+
+> A simple python wrapper for using Sonetel's REST APIs
+
+## What it contains
+<!-- The actual contents — services, modules, assets. Fill in. -->
+
+## Ownership
+- **Code owner:** Aashish Joshi (aashish-joshi)
+
+## Notes
+Keep — Python SDK customers use to work with the Sonetel API (confirmed 2026-06-09).


### PR DESCRIPTION
Adds the canonical `.github/REPO-INFO.md` — facet front-matter (mirrored from the tech-debt registry) + knowledge-article prose. Part of Sonetel/tech-debt#38. Metadata/docs only; no code change.